### PR TITLE
Create and Update sprint timeframe fix

### DIFF
--- a/src/components/shared/SprintForm.js
+++ b/src/components/shared/SprintForm.js
@@ -23,7 +23,7 @@ const SprintForm = ({ sprint, handleSubmit, handleChange, match }) => {
           name="timeframe"
           onChange={handleChange}
         >
-          <option defaultValue>Select number of weeks</option>
+          <option selected disabled>Select number of weeks</option>
           <option>1</option>
           <option>2</option>
           <option>3</option>


### PR DESCRIPTION
I fixed the timeframe selection so that the user cannot select the option select number of weeks so that the form does not crash.